### PR TITLE
Fix page title to show remaining time

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React Redux App</title>
+    <title>Pom-Cal - Pomodoro Timer with Google Calendar</title>
   </head>
   <body id="body">
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/PomClock.jsx
+++ b/src/components/PomClock.jsx
@@ -343,13 +343,12 @@ class PomodoroClock extends Component {
    * Render the pomodoro timer
    */
   render() {
-    // document.title = `${calcTimeLeft(this.state.timeLeft)} [${this.state.timerLabel}] - Pom-Cal`;
     return (
       <div id="pomodoro-clock-inside">
         <div className="btn-set timer">
           <div>
             <div id="timer-label" className="label">{this.state.timerLabel}</div>
-            <TimeLeft timeLeft={this.state.timeLeft} />
+            <TimeLeft timeLeft={this.state.timeLeft} timerLabel={this.state.timerLabel} />
             <div>
               Completed Sessions:
               {' '}

--- a/src/components/TimeLeft.jsx
+++ b/src/components/TimeLeft.jsx
@@ -9,6 +9,17 @@ class TimeLeft extends Component {
 
     this.mmss = this.mmss.bind(this);
     this.calcTimeLeft = this.calcTimeLeft.bind(this);
+    this.displayTimeInTitle = this.displayTimeInTitle.bind(this);
+  }
+
+  componentDidMount() {
+    const { timeLeft, timerLabel } = this.props;
+    this.displayTimeInTitle(timeLeft, timerLabel);
+  }
+
+  componentDidUpdate() {
+    const { timeLeft, timerLabel } = this.props;
+    this.displayTimeInTitle(timeLeft, timerLabel);
   }
 
   /**
@@ -31,6 +42,15 @@ class TimeLeft extends Component {
     const seconds = Math.floor(timeLeft % (60));
 
     return this.mmss(minutes, seconds);
+  }
+
+  /**
+   * Update page title with given time and label
+   * @param {Number} timeLeft
+   * @param {String} timerLabel
+   */
+  displayTimeInTitle(timeLeft, timerLabel) {
+    document.title = `${this.calcTimeLeft(timeLeft)} [${timerLabel}] - Pom-Cal`;
   }
 
 


### PR DESCRIPTION
ページのタイトルに残り時間を表示する機能。
残り時間の表示処理を TimeLeft として別モジュールに切り分けたので、タイトルの更新処理も TimeLeft モジュール側に移動。